### PR TITLE
WA5ZNU: news.py bug fixes and enhancements

### DIFF
--- a/badger_os/examples/news.py
+++ b/badger_os/examples/news.py
@@ -131,7 +131,8 @@ def draw_qr_code(ox, oy, size, code):
 def get_rss(url):
     try:
         stream = urequest.urlopen(url)
-        output = list(parse_xml_stream(stream, [b"title", b"description", b"guid", b"pubDate"], b"item"))
+        # [klotz] accommodate guid or link
+        output = list(parse_xml_stream(stream, [b"title", b"description", b"guid", b"link", b"pubDate"], b"item"))
         return output
 
     except OSError as e:
@@ -169,7 +170,8 @@ def draw_page():
         page = state["current_page"]
         display.set_pen(0)
         display.text(feed[page]["title"], 2, 30, WIDTH - 130, 2)
-        code.set_text(feed[page]["guid"])
+        # [klotz]
+        code.set_text(feed[page]["link"] or feed[page]["guid"])
         draw_qr_code(WIDTH - 100, 25, 100, code)
 
     else:

--- a/badger_os/examples/news.py
+++ b/badger_os/examples/news.py
@@ -15,7 +15,7 @@ code = qrcode.QRCode()
 
 state = {
     "current_page": 0,
-    "feed": 2
+    "feed": 0
 }
 
 badger_os.state_load("news", state)

--- a/badger_os/examples/news.py
+++ b/badger_os/examples/news.py
@@ -136,7 +136,8 @@ def get_rss(url):
         return output
 
     except OSError as e:
-        print(e)
+        # [klotz] better errors
+        print("error", url, e)
         return False
 
     finally:

--- a/badger_os/examples/news.py
+++ b/badger_os/examples/news.py
@@ -146,7 +146,7 @@ def get_rss(url):
 # Connects to the wireless network. Ensure you have entered your details in WIFI_CONFIG.py :).
 display.connect()
 
-print(state["feed"])
+print(f"feed: {state["feed"]}")
 feed = get_rss(URL[state["feed"]])
 
 
@@ -223,4 +223,5 @@ while True:
         changed = True
 
     if changed:
+        print(f"feed: {state["feed"]} page: {state["current_page"]} url: {URL[state["feed"]]}")
         draw_page()

--- a/badger_os/examples/news.py
+++ b/badger_os/examples/news.py
@@ -95,7 +95,14 @@ def parse_xml_stream(s, accept_tags, group_by, max_items=3):
 
             else:
                 current_tag = read_until(s, b">")
-                tag += [next_char + current_tag.split(b" ")[0]]
+                # [klotz] fix short-form close XML
+                if current_tag[-1:] == b'/':
+                    # <foo />: there's no text content, and don't process attributes, so ignore
+                    # current_tag = next_char + current_tag.split(b" ")[0].split(b"/")[0]
+                    current_tag = None
+                else:
+                    current_tag = next_char + current_tag.split(b" ")[0]
+                    tag += [current_tag]
                 text = b""
                 gc.collect()
 

--- a/badger_os/examples/news.py
+++ b/badger_os/examples/news.py
@@ -139,6 +139,8 @@ def get_rss(url):
         print(e)
         return False
 
+    finally:
+        stream.close()
 
 # Connects to the wireless network. Ensure you have entered your details in WIFI_CONFIG.py :).
 display.connect()

--- a/badger_os/examples/news.py
+++ b/badger_os/examples/news.py
@@ -214,6 +214,7 @@ while True:
     if button_a.value():
         state["feed"] = 0
         state["current_page"] = 0
+        feed = None
         feed = get_rss(URL[state["feed"]])
         badger_os.state_save("news", state)
         changed = True
@@ -221,6 +222,7 @@ while True:
     if button_b.value():
         state["feed"] = 1
         state["current_page"] = 0
+        feed = None
         feed = get_rss(URL[state["feed"]])
         badger_os.state_save("news", state)
         changed = True
@@ -228,6 +230,7 @@ while True:
     if button_c.value():
         state["feed"] = 2
         state["current_page"] = 0
+        feed = None
         feed = get_rss(URL[state["feed"]])
         badger_os.state_save("news", state)
         changed = True

--- a/badger_os/examples/news.py
+++ b/badger_os/examples/news.py
@@ -162,7 +162,18 @@ def draw_page():
     display.set_pen(0)
     display.rectangle(0, 0, WIDTH, 20)
     display.set_pen(15)
-    display.text("News", 3, 4)
+
+    # [klotz]
+    if feed:
+        def urlhostname(url):
+            """return hostname of url, without external dependencies"""
+            return url.split('//')[-1].split('/')[0]
+        url = URL[state["feed"]]
+        hostname = urlhostname(url)
+        display.text("News " + hostname, 3, 4)
+    else:
+        display.text("News", 3, 4)
+
     display.text("Page: " + str(state["current_page"] + 1), WIDTH - display.measure_text("Page:  ") - 4, 4)
     display.set_pen(0)
 
@@ -171,7 +182,6 @@ def draw_page():
     # Draw articles from the feed if they're available.
     if feed:
         page = state["current_page"]
-        display.set_pen(0)
         display.text(feed[page]["title"], 2, 30, WIDTH - 130, 2)
         # [klotz]
         code.set_text(feed[page]["link"] or feed[page]["guid"])


### PR DESCRIPTION
A set of fixes and enhancements, mostly independent:

- Allow XML empty tags
- Accomodate 'guid' or 'link' in RSS feed, and use 'guid' only if 'link' is not present
- Fix OOM by closing stream: https://github.com/micropython/micropython-lib/issues/175
- Log URL in get_rss error
- Serial print feed info on button push
- Add Hostname To RSS Reader Header
- Try to save memory by clearing feed before fetching new one

And one preference change:
- start with feed 0 instead of feed 2

