### PR TITLE
Reimplement battery voltage read and display for Badger 2040 W

### DIFF
--- a/badger_os/launcher.py
+++ b/badger_os/launcher.py
@@ -21,6 +21,9 @@ else:
     # Otherwise restore previously running app
     badger_os.state_launch()
 
+# for e.g. 2xAAA batteries, try max 3.4 min 3.0
+MAX_BATTERY_VOLTAGE = 4.0
+MIN_BATTERY_VOLTAGE = 3.2
 
 display = badger2040.Badger2040()
 display.set_font("bitmap8")
@@ -47,6 +50,29 @@ WIDTH = 296
 
 def map_value(input, in_min, in_max, out_min, out_max):
     return (((input - in_min) * (out_max - out_min)) / (in_max - in_min)) + out_min
+
+
+def draw_battery(level, x, y):
+    # Outline
+    display.set_pen(15)
+    display.rectangle(x, y, 19, 10)
+    # Terminal
+    display.rectangle(x + 19, y + 3, 2, 4)
+    display.set_pen(0)
+    display.rectangle(x + 1, y + 1, 17, 8)
+    if level < 1:
+        display.set_pen(0)
+        display.line(x + 3, y, x + 3 + 10, y + 10)
+        display.line(x + 3 + 1, y, x + 3 + 11, y + 10)
+        display.set_pen(15)
+        display.line(x + 2 + 2, y - 1, x + 4 + 12, y + 11)
+        display.line(x + 2 + 3, y - 1, x + 4 + 13, y + 11)
+        return
+    # Battery Bars
+    display.set_pen(15)
+    for i in range(4):
+        if level / 4 > (1.0 * i) / 4:
+            display.rectangle(i * 4 + x + 2, y + 2, 3, 6)
 
 
 def draw_disk_usage(x):
@@ -110,6 +136,10 @@ def render():
     display.set_pen(0)
     display.rectangle(0, 0, WIDTH, 16)
     draw_disk_usage(90)
+    if badger2040.is_wireless():
+        vbat = badger_os.get_battery_level()
+        bat = int(map_value(vbat, MIN_BATTERY_VOLTAGE, MAX_BATTERY_VOLTAGE, 0, 4))
+        draw_battery(bat, WIDTH - 22 - 3, 3)
     display.set_pen(15)
     display.text("badgerOS", 4, 4, WIDTH, 1.0)
 

--- a/firmware/PIMORONI_BADGER2040W/lib/badger_os.py
+++ b/firmware/PIMORONI_BADGER2040W/lib/badger_os.py
@@ -7,28 +7,17 @@ import badger2040
 
 
 def get_battery_level():
-    return 0
-    # Battery measurement
-    vbat_adc = machine.ADC(badger2040.PIN_BATTERY)
-    vref_adc = machine.ADC(badger2040.PIN_1V2_REF)
-    vref_en = machine.Pin(badger2040.PIN_VREF_POWER)
-    vref_en.init(machine.Pin.OUT)
-    vref_en.value(0)
+    from machine import Pin, ADC
 
-    # Enable the onboard voltage reference
-    vref_en.value(1)
+    # Setup pins
+    Pin(25, Pin.OUT, value=1)  # Deselect Wi-Fi module
+    Pin(29, Pin.IN, pull=None)  # Set VSYS ADC pin floating
 
-    # Calculate the logic supply voltage, as will be lower that the usual 3.3V when running off low batteries
-    vdd = 1.24 * (65535 / vref_adc.read_u16())
-    vbat = (
-        (vbat_adc.read_u16() / 65535) * 3 * vdd
-    )  # 3 in this is a gain, not rounding of 3.3V
+    # VSYS measurement
+    vsys_adc = ADC(29)
+    vsys = (vsys_adc.read_u16() / 65535) * 3 * 3.3
 
-    # Disable the onboard voltage reference
-    vref_en.value(0)
-
-    # Convert the voltage to a level to display onscreen
-    return vbat
+    return vsys
 
 
 def get_disk_usage():


### PR DESCRIPTION
This measures VSYS ADC on Pi Pico W, which should be OK accuracy since the 3.3V reference is provided from the Pico W's buck regulator. Battery display is only enabled for Badger 2040 W because I didn't reimplement the battery measuring logic for Badger 2040.

Nothing special needs to be done to restore pin 29 back to output because the driver in Pico SDK automatically sets it on starting SPI comms.

Resolves #26