### PR TITLE
Set PCF85063A after `ntptime.settime()`

### DIFF
--- a/badger_os/examples/clock.py
+++ b/badger_os/examples/clock.py
@@ -15,6 +15,7 @@ if badger2040.is_wireless():
         display.connect()
         if display.isconnected():
             ntptime.settime()
+            badger2040.pico_rtc_to_pcf()
     except (RuntimeError, OSError) as e:
         print(f"Wireless Error: {e.value}")
 


### PR DESCRIPTION
My Badger 2040 W always shows the clock as 2000-01-01 00:00:00, even though I can access the Internet. This issue arises from `badger2040.pcf_to_pico_rtc()`, which overwrites Pico's RTC using PCF85063A, after `ntptime.settime()` is called. However, PCF85063A is never set before.

This commit sets the PCF85063A using the freshly synced time obtained from pool.ntp.org.