### PR TITLE
adding https to example urls to fix redirects error

### DIFF
--- a/badger_os/examples/news.py
+++ b/badger_os/examples/news.py
@@ -7,9 +7,9 @@ import qrcode
 import badger_os
 
 # URLS to use (Entertainment, Science and Technology)
-URL = ["http://feeds.bbci.co.uk/news/entertainment_and_arts/rss.xml",
-       "http://feeds.bbci.co.uk/news/science_and_environment/rss.xml",
-       "http://feeds.bbci.co.uk/news/technology/rss.xml"]
+URL = ["https://feeds.bbci.co.uk/news/entertainment_and_arts/rss.xml",
+       "https://feeds.bbci.co.uk/news/science_and_environment/rss.xml",
+       "https://feeds.bbci.co.uk/news/technology/rss.xml"]
 
 code = qrcode.QRCode()
 


### PR DESCRIPTION
The news.py example was using http urls and gave the error

Redirects not yet supported

With thanks to ahnlak on the forums he helped reference a Discord discussion where amending the url to https may fix the issue and testing it it does resolve this issue. https://forums.pimoroni.com/t/badgerw-news-example-redirects-not-yet-supported/23682

I have amended the url's in the examples/news.py 