### PR TITLE
Display "Wifi connection failed" on screen after timeout

### DIFF
--- a/firmware/PIMORONI_BADGER2040W/lib/badger2040.py
+++ b/firmware/PIMORONI_BADGER2040W/lib/badger2040.py
@@ -238,10 +238,10 @@ class Badger2040():
         self.display.set_pen(15)
         self.display.clear()
         self.display.set_pen(0)
-        if status == True:
+        if status:
             self.display.text("Connected!", 10, 10, 300, 0.5)
             self.display.text(ip, 10, 30, 300, 0.5)
-        elif status == False:
+        elif status is False:
             self.display.text("WiFi connection failed", 10, 10, 300, 0.5)
         else:
             self.display.text("Connecting...", 10, 10, 300, 0.5)

--- a/firmware/PIMORONI_BADGER2040W/lib/badger2040.py
+++ b/firmware/PIMORONI_BADGER2040W/lib/badger2040.py
@@ -238,9 +238,11 @@ class Badger2040():
         self.display.set_pen(15)
         self.display.clear()
         self.display.set_pen(0)
-        if status:
+        if status == True:
             self.display.text("Connected!", 10, 10, 300, 0.5)
             self.display.text(ip, 10, 30, 300, 0.5)
+        elif status == False:
+            self.display.text("WiFi connection failed", 10, 10, 300, 0.5)
         else:
             self.display.text("Connecting...", 10, 10, 300, 0.5)
         self.update()


### PR DESCRIPTION
This PR adds functionality to the default Wifi status handler on Badger 2040W.

If the connection times out, "WiFi connection failed" is displayed on the screen, rather than hanging on "Connecting..." after 60s.

Thank you!