### PR TITLE
Redundancy in Imports

### DIFF
--- a/firmware/PIMORONI_BADGER2040/lib/badger_os.py
+++ b/firmware/PIMORONI_BADGER2040/lib/badger_os.py
@@ -81,7 +81,6 @@ def state_save(app, data):
             f.write(json.dumps(data))
             f.flush()
     except OSError:
-        import os
         try:
             os.stat("/state")
         except OSError:

--- a/firmware/PIMORONI_BADGER2040W/lib/badger_os.py
+++ b/firmware/PIMORONI_BADGER2040W/lib/badger_os.py
@@ -81,7 +81,6 @@ def state_save(app, data):
             f.write(json.dumps(data))
             f.flush()
     except OSError:
-        import os
         try:
             os.stat("/state")
         except OSError:


### PR DESCRIPTION
Imports os twice is imported twice in both versions of badger_os.py. Once globally and once inside the state_save() function. This is redundant and the second import has been removed.